### PR TITLE
Fixing the redcarpet build warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Dependencies
-markdown:         redcarpet
+markdown:         kramdown
 highlighter:      rouge
 
 # Permalinks


### PR DESCRIPTION
kramdown is the default and only supported markdown converter on GH pages from 1st May 2016.
